### PR TITLE
🐛 :: 홈 레이아웃

### DIFF
--- a/src/routes/home/+page.svelte
+++ b/src/routes/home/+page.svelte
@@ -9,7 +9,7 @@
         bgColor: '#DBE1FF',
         width: '130px',
         height: '224px',
-        marginLeft: '16px',
+        marginLeft: '5px',
         marginTop: '0px'
     };
 
@@ -37,7 +37,7 @@
         bgColor: '#FFDBF5',
         width: '130px',
         height: '201px',
-        marginLeft: '16px',
+        marginLeft: '5px',
         marginTop: '0px'
     };
 
@@ -132,22 +132,25 @@
     }
 
     .card img {
-        width: 74px;
-        height: 74px;
-        margin-bottom: 10px;
+        width: 80px;
+        height: 80px;
+        margin-bottom: 8px;
         margin-top: auto;  
         transform: translateY(-30%); 
+        align-items: center;
+        margin-left: 20px;
+
     }
 
     .card h2 {
-        color: #333;
-        font-size: 24px;
+        color: #000000;
+        font-size: 26px;
         margin: 0;
     }
 
     .card p {
-        font-size: 14px;
-        color: #666;
+        font-size: 12px;
+        color: #363636;
         margin: 0;
     }
 </style>


### PR DESCRIPTION
## 한 일
- 홈 화면에서 세션마다 크기 및 레이아웃이 맞지 않는 문제를 해결했어요.

## 고쳐야할 점
 ```
     const card1 = {
        id: 1,
        recipient: '희성',
        date: '6월 18일',
        icon: 'diamond.svg',
        timeLeft: '79:33',
        daysLeft: '약 3일 남음',
        bgColor: '#DBE1FF',
        width: '130px',
        height: '224px',
        marginLeft: '5px',
        marginTop: '0px'
    };
```
이 코드 진짜 별로에요. 코드를 효율적으로 바꾸는 작업이 필요해요. 특히 각각의 세션에 아이콘의 크기를 다 다르게 조정할 수 있도록 .card1-img 형식으로 바꿀 필요가 있어요.

## 사진
![스크린샷 2024-08-23 01-18-34](https://github.com/user-attachments/assets/d46c62f5-e473-41fb-a009-593208cd956c)
